### PR TITLE
Fix --fixture-graph-output-dir and --fixture-graph-output-type

### DIFF
--- a/pytest_fixture_tools/plugin.py
+++ b/pytest_fixture_tools/plugin.py
@@ -37,10 +37,10 @@ def pytest_addoption(parser):
                     action="store_true", dest="fixture_graph", default=False,
                     help="create .dot fixture graph for each test")
     group.addoption('--fixture-graph-output-dir',
-                    action="store_true", dest="fixture_graph_output_dir", default="artifacts",
+                    action="store", dest="fixture_graph_output_dir", default="artifacts",
                     help="select the location for the output of fixture graph. defaults to 'artifacts'")
     group.addoption('--fixture-graph-output-type',
-                    action="store_true", dest="fixture_graph_output_type", default="png",
+                    action="store", dest="fixture_graph_output_type", default="png",
                     help="select the type of the output for the fixture graph. defaults to 'png'")
 
 


### PR DESCRIPTION
Command line options `--fixture-graph-output-dir` and `--fixture-graph-output-type` wouldn't allow you to actually pass custom value, since their action was to store a boolean:

```
$ pytest  --fixture-graph --fixture-graph-output-type=pdf
ERROR: usage: pytest [options] [file_or_dir] [file_or_dir] [...]
pytest: error: argument --fixture-graph-output-type: ignored explicit argument 'pdf'

$ pytest  --fixture-graph --fixture-graph-output-dir=./foo
ERROR: usage: pytest [options] [file_or_dir] [file_or_dir] [...]
pytest: error: argument --fixture-graph-output-dir: ignored explicit argument './foo'
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-fixture-tools/5)
<!-- Reviewable:end -->
