### PR TITLE
Python and pytest compatibility fixes

### DIFF
--- a/pytest_fixture_tools/plugin.py
+++ b/pytest_fixture_tools/plugin.py
@@ -37,10 +37,10 @@ def pytest_addoption(parser):
                     action="store_true", dest="fixture_graph", default=False,
                     help="create .dot fixture graph for each test")
     group.addoption('--fixture-graph-output-dir',
-                    action="store_true", dest="fixture_graph_output_dir", default="artifacts",
+                    action="store", dest="fixture_graph_output_dir", default="artifacts",
                     help="select the location for the output of fixture graph. defaults to 'artifacts'")
     group.addoption('--fixture-graph-output-type',
-                    action="store_true", dest="fixture_graph_output_type", default="png",
+                    action="store", dest="fixture_graph_output_type", default="png",
                     help="select the type of the output for the fixture graph. defaults to 'png'")
 
 

--- a/pytest_fixture_tools/plugin.py
+++ b/pytest_fixture_tools/plugin.py
@@ -4,7 +4,7 @@ import py
 import os
 import errno
 
-from _pytest.python import getlocation
+from _pytest.compat import getlocation
 from collections import defaultdict
 
 import pydot

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,3 +1,2 @@
-pytest-pep8
 pytest-cov
 pytest-cache

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     ] + [('Programming Language :: Python :: %s' % x) for x in '2.6 2.7 3.0 3.1 3.2 3.3'.split()],
     cmdclass={'test': ToxTestCommand},
     install_requires=[
-        'pytest', 'pydot'
+        'pytest', 'pydot', 'py'
     ],
     # the following makes a plugin available to py.test
     entry_points={

--- a/tests/test_fixtrue_graph.py
+++ b/tests/test_fixtrue_graph.py
@@ -22,7 +22,7 @@ def test_fixture_graph_created(testdir):
     sub1.join("test_in_sub1.py").write("def test_1(arg1): pass")
     sub2.join("test_in_sub2.py").write("def test_2(arg1): pass")
 
-    result = testdir.runpytest_subprocess('--fixture-graph', '-s')
+    result = testdir.runpytest_subprocess('--fixture-graph', '-s', '--fixture-graph-output-type', 'dot')
 
     result.stdout.fnmatch_lines("created artifacts/fixture-graph-sub1-test_in_sub1.py__test_1.dot.")
     result.stdout.fnmatch_lines('created artifacts/fixture-graph-sub1-sub2-test_in_sub2.py__test_2.dot.')

--- a/tox.ini
+++ b/tox.ini
@@ -18,5 +18,4 @@ deps =
     hg+https://bitbucket.org/hpk42/pytest
 
 [pytest]
-pep8maxlinelength=120
-addopts = pytest_fixture_tools tests --pep8
+addopts = pytest_fixture_tools tests


### PR DESCRIPTION
Various fixes to get the plugin compatible with the latest version of pytest and Python.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-fixture-tools/7)
<!-- Reviewable:end -->
