### PR TITLE
Fix typo in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ You can generate the usage fixture graph like that:
     pytest --fixture-graph --fixture-graph-output-dir=./test_output
 
     # you can also change the output type of the graphs (any of graphvis supported outputs types):
-    pytest --fixture-graph --fixture-graph-type=jpg
+    pytest --fixture-graph --fixture-graph-output-type=jpg
 
 The output would be like that:
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-fixture-tools/10)
<!-- Reviewable:end -->
