### PR TITLE
Fix getfixturedefs call

### DIFF
--- a/pytest_fixture_tools/plugin.py
+++ b/pytest_fixture_tools/plugin.py
@@ -91,7 +91,7 @@ def _show_fixture_duplicates_main(config, session):
                        else fm._arg2fixturedefs)
     for item in session.items:
         for argname in arg2fixturedefs:
-            fixturedefs = fm.getfixturedefs(argname, item.nodeid)
+            fixturedefs = fm.getfixturedefs(argname, item)
             assert fixturedefs is not None
             if not fixturedefs:
                 continue


### PR DESCRIPTION
**Problem:**
Test runs with --show-fixture-duplicates fail with error:
```
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/Users/user/Code/e2e/venv/lib/python3.12/site-packages/_pytest/fixtures.py", line 1771, in _matchfactories
INTERNALERROR>     parentnodeids = {n.nodeid for n in node.iter_parents()}
INTERNALERROR>                                        ^^^^^^^^^^^^^^^^^
INTERNALERROR> AttributeError: 'str' object has no attribute 'iter_parents'
INTERNALERROR> 
INTERNALERROR> During handling of the above exception, another exception occurred:
INTERNALERROR> 
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/Users/user/Code/e2e/venv/lib/python3.12/site-packages/_pytest/main.py", line 285, in wrap_session
INTERNALERROR>     session.exitstatus = doit(config, session) or 0
INTERNALERROR>                          ^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/user/Code/e2e/venv/lib/python3.12/site-packages/pytest_fixture_tools/plugin.py", line 94, in _show_fixture_duplicates_main
INTERNALERROR>     fixturedefs = fm.getfixturedefs(argname, item.nodeid)
INTERNALERROR>                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/user/Code/e2e/venv/lib/python3.12/site-packages/_pytest/fixtures.py", line 1765, in getfixturedefs
INTERNALERROR>     return tuple(self._matchfactories(fixturedefs, node))
INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/user/Code/e2e/venv/lib/python3.12/site-packages/_pytest/fixtures.py", line 1773, in _matchfactories
INTERNALERROR>     raise ValueError("node must be a Node instance")
INTERNALERROR> ValueError: node must be a Node instance
```
It happens because `getfixturedefs` takes a Node object, not a node ID string.
https://github.com/pytest-dev/pytest/blob/949c7711b3e22ab94110f1ae4fc307cda2f9e379/src/_pytest/fixtures.py#L1824

This PR fix the problem.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-fixture-tools/12)
<!-- Reviewable:end -->
